### PR TITLE
TD-267: deprecate enum fields

### DIFF
--- a/openapi/components/schemas/BankCardDetails.yaml
+++ b/openapi/components/schemas/BankCardDetails.yaml
@@ -28,6 +28,11 @@ properties:
       - googlepay
       - samsungpay
       - yandexpay
+      - unknown
+    deprecated: true
+  tokenProviderName:
+    description: Провайдер платежных токенов
+    type: string
   issuerCountry:
     description: Страна эмитент (alpha-3 код по стандарту ISO_3166-1)
     type: string

--- a/openapi/components/schemas/CryptoCurrency.yaml
+++ b/openapi/components/schemas/CryptoCurrency.yaml
@@ -7,3 +7,5 @@ enum:
   - ripple
   - ethereum
   - zcash
+  - unknown
+deprecated: true

--- a/openapi/components/schemas/CryptoCurrencyType.yaml
+++ b/openapi/components/schemas/CryptoCurrencyType.yaml
@@ -1,0 +1,2 @@
+description: Тип криптовалюты
+type: string

--- a/openapi/components/schemas/CryptoWalletDetails.yaml
+++ b/openapi/components/schemas/CryptoWalletDetails.yaml
@@ -3,3 +3,5 @@ required:
 properties:
   cryptoCurrency:
     $ref: '../schemas/CryptoCurrency.yaml'
+  cryptoCurrencyType:
+    $ref: '../schemas/CryptoCurrencyType.yaml'

--- a/openapi/components/schemas/PaymentTerminalDetails.yaml
+++ b/openapi/components/schemas/PaymentTerminalDetails.yaml
@@ -1,5 +1,6 @@
 required:
   - provider
+  - providerName
 properties:
   provider:
     type: string
@@ -9,3 +10,7 @@ properties:
       - alipay
       - qps
       - uzcard
+      - unknown
+    deprecated: true
+  providerName:
+    type: string


### PR DESCRIPTION
Due to the future removal of enum fields from damsel protocol

https://github.com/valitydev/damsel/blob/1d60b20f2136938c43902dd38a80ae70f03e4a14/proto/domain.thrift#L1882
https://github.com/valitydev/damsel/blob/1d60b20f2136938c43902dd38a80ae70f03e4a14/proto/domain.thrift#L2050
https://github.com/valitydev/damsel/blob/1d60b20f2136938c43902dd38a80ae70f03e4a14/proto/domain.thrift#L1909
https://github.com/valitydev/damsel/blob/1d60b20f2136938c43902dd38a80ae70f03e4a14/proto/domain.thrift#L1935